### PR TITLE
Fix date parsing for Firefox compatibility

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -54,7 +54,12 @@ export type GameCountGetRequest = {
 
 export async function getLastCompletedDate(): Promise<Date> {
   const resp = await fetch(`${config.apiUrl}/game/latest_completed_date`);
-  return new Date(await resp.text());
+
+  // `dateString` is surrounded with quotes like "2025-05-21".
+  // Because of this, the `Date` object was not being constructed properly on Firefox.
+  const dateString = await resp.text();
+  const trimmedDateString = dateString.slice(1, -1);
+  return new Date(trimmedDateString);
 }
 
 export async function getGames(
@@ -86,6 +91,8 @@ export async function getGames(
       params.append("rhe", n.toString());
     });
   }
+
+  console.log(params);
 
   const resp = await fetch(`${config.apiUrl}/game?${params.toString()}`);
 


### PR DESCRIPTION
The `GET /game/latest_completed_date` endpoint returns a date string with surrounding quotes ("2025-05-21").
When creating a `Date` object with this string:
```js
new Date("\"2025-05-21\"")
```
This works in Chrome and Edge but fails in Firefox, resulting in an invalid date.
This PR fixes the issue by trimming the surrounding quotes before constructing the `Date` object, ensuring cross-browser compatibility.

Closes #6 